### PR TITLE
Use setup-java action to cache dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,16 +22,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java-version }}
-
-      - name: Setup gradle wrapper cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
+          cache: 'gradle'
 
       - name: Run check
         run: ./gradlew clean build


### PR DESCRIPTION
Signed-off-by: jongwooo <jongwooo.han@gmail.com>

## Description

Updated workflows to cache dependencies using [actions/setup-java](https://github.com/actions/setup-java#caching-packages-dependencies). `setup-java@v3` or newer has caching **built-in**.

**AS-IS**

```yaml
- name: Setup JDK
  uses: actions/setup-java@v3
  with:
    distribution: 'temurin'
    java-version: ${{ matrix.java-version }}

- name: Setup gradle wrapper cache
  uses: actions/cache@v3
  with:
    path: |
      ~/.gradle/caches
      ~/.gradle/wrapper
    key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
    restore-keys: |
      ${{ runner.os }}-gradle-
```

**TO-BE**

```yaml
- name: Setup JDK
  uses: actions/setup-java@v3
  with:
    distribution: 'temurin'
    java-version: ${{ matrix.java-version }}
    cache: 'gradle'
```

> It’s literally a one line change to pass the `cache: 'gradle'` input parameter.

## References
- [actions/setup-java#caching-packages-dependencies](https://github.com/actions/setup-java#caching-packages-dependencies)
- [thearchivelog.dev/article/caching-dependencies-to-speed-up-workflows/](https://thearchivelog.dev/article/caching-dependencies-to-speed-up-workflows/)

