### PR TITLE
Bump up kotlin build version (1.7.10 -> 1.9.10)

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -9,7 +9,7 @@ repositories {
 }
 
 dependencies {
-    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.10")
+    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.10")
     implementation("org.jlleitschuh.gradle.ktlint:org.jlleitschuh.gradle.ktlint.gradle.plugin:10.3.0")
     implementation("org.jetbrains.kotlinx:kover:0.6.1")
 }


### PR DESCRIPTION
This doesn't break backward compatibility for kotlin user since compiler options is set.

https://github.com/naver/spring-batch-plus/blob/d1fd97c416bfea32c9b606b9ba32ad1863c1995f/buildSrc/src/main/kotlin/spring.batch.plus.kotlin-conventions.gradle.kts#L14-L15